### PR TITLE
Fix MD5 file extension to upper case

### DIFF
--- a/src/main/java/mpern/sap/commerce/ccv1/CloudServicesPackagingPlugin.java
+++ b/src/main/java/mpern/sap/commerce/ccv1/CloudServicesPackagingPlugin.java
@@ -136,7 +136,7 @@ public class CloudServicesPackagingPlugin implements Plugin<Project> {
             args.put("file", zipPackage.getArchivePath());
             args.put("format", "MD5SUM");
             p.getAnt().invokeMethod("checksum", args);
-            Path resolve = zipPackage.getDestinationDir().toPath().resolve(zipPackage.getArchiveName() + ".md5");
+            Path resolve = zipPackage.getDestinationDir().toPath().resolve(zipPackage.getArchiveName() + ".MD5");
             Path target = zipPackage.getDestinationDir().toPath().resolve(zipPackage.getBaseName() + ".md5");
             try {
                 Files.delete(target);


### PR DESCRIPTION
The Ant task produces a file with upper case file extension like *.MD5.

On Linux environments the call to Files.move(...) fails since its implementation is case sensitive on these environments.