### PR TITLE
Package validation fails

### DIFF
--- a/src/main/java/mpern/sap/commerce/ccv1/CloudServicesPackagingPlugin.java
+++ b/src/main/java/mpern/sap/commerce/ccv1/CloudServicesPackagingPlugin.java
@@ -165,7 +165,7 @@ public class CloudServicesPackagingPlugin implements Plugin<Project> {
             t.doLast(a -> {
                 Map<String, Object> args = new HashMap<>();
                 args.put("file", zipPackage.getArchivePath());
-                args.put("format", "MD5SUM");
+                args.put("pattern", "{0} {1}");
                 args.put("fileext", ".MD5");
                 p.getAnt().invokeMethod("checksum", args);
                 try {


### PR DESCRIPTION
Package validation using validator 2 (ypv2.sh) and template version 2.3 fails, while validating 1_master.json rules. Format "MD5SUM" uses pattern "{0} *{1}". Package validation fails because of asterisk char. Replaced format with pattern to generate MD5 file without asterisk.