### PR TITLE
move manifest to core-customize folder in repo root

### DIFF
--- a/src/main/java/mpern/sap/commerce/ccv2/CloudV2Plugin.java
+++ b/src/main/java/mpern/sap/commerce/ccv2/CloudV2Plugin.java
@@ -39,7 +39,7 @@ public class CloudV2Plugin implements Plugin<Project> {
 
     public static final String EXTENSION_PACK = "cloudExtensionPack";
     private static final String GROUP = "CCv2 Build";
-    private static final String MANIFEST_PATH = "manifest.json";
+    private static final String MANIFEST_PATH = "core-customize/manifest.json";
     private CCv2Extension extension;
 
     @Override


### PR DESCRIPTION
From CCv2 documentation:
  
  The build manifest defines how your application should be built by including baseline properties with specific configurations. It is a manifest.json file situated at the root level of your code repository, inside the *core-customize* directory.

Building with comerce-gradle-plugin CCV2 tasks generates errors looking for manifest.json in the repo root. It would be helpful to have only one place for manifest.json.